### PR TITLE
fix: lang defaults to en-US

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,7 @@ const ogTitle = 'Vite'
 const ogUrl = 'https://es.vitejs.dev'
 
 export default defineConfig({
+  lang: 'es',
   title: 'Vite',
   description: 'Herramienta frontend de próxima generación',
   head: [


### PR DESCRIPTION
Hey, I noticed that the `<html lang>` attribute for [es.vitejs.dev](https://es.vitejs.dev/) was `en-US`. This is a major accessibility issue because it will make all screen readers announce the site’s content with an english voice.