### PR TITLE
"Edit page" GitHub link points to incorrect path

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     editLink: {
-      pattern: 'https://github.com/vitejs/vite/edit/main/docs/:path',
+      pattern: 'https://github.com/vitejs/docs-es/edit/main/docs/:path',
       text: 'Sugerir cambios para esta página'
     },
     socialLinks: [


### PR DESCRIPTION
Source repo should be updated to `vitejs/docs-es` for the edit link to work.