### PR TITLE
fix: Skip inlining Git LFS placeholders (fix #9714) (#257)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -54,7 +54,7 @@ Especifica el directorio en el que se alojarán los recursos generados (en relac
 Los recursos importados o a los que se hace referencia que son más pequeños que este umbral se insertarán como URL base64 para evitar solicitudes http adicionales. Configurar en `0` para deshabilitar la inserción por completo.
 
 ::: tip Nota
-Si especificas `build.lib`, `build.assetsInlineLimit` se ignorará y los recursos siempre serán insertados, independientemente del tamaño del archivo.
+Si especificas `build.lib`, `build.assetsInlineLimit` se ignorará y los recursos siempre serán insertados, independientemente del tamaño del archivo o de ser un marcador de posición Git LFS.
 :::
 
 ## build.cssCodeSplit

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -26,6 +26,8 @@ El comportamiento es similar al `file-loader` de webpack. La diferencia es que l
 
 - Los recursos más pequeños en bytes que la opción [`assetsInlineLimit`](/config/build-options#build-assetsinlinelimit) se insertarán como URL de datos en base64.
 
+- Los marcadores de posición de Git LFS se excluyen automáticamente de la inserción porque no contienen el contenido del archivo que representan. Para obtener la inserción, asegúrate de descargar el contenido del archivo a través de Git LFS antes de construir.
+
 ### Importaciones de URL explícita
 
 Los recursos que no están incluidos en la lista interna o en `assetsInclude`, se pueden importar explícitamente como una URL usando el sufijo `?url`. Esto es útil, por ejemplo, para importar los [Houdini Paint Worklets](https://houdini.how/usage).


### PR DESCRIPTION
resolves #257 
Translated text from [vitejs/vite@`9c7e43d`](https://github.com/vitejs/vite/commit/9c7e43d030f07f50f7cf5ef490e74c9425f5ce0f)