### PR TITLE
Updated "Éste" with "Este". Explanation bellow:

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,7 +22,7 @@ La configuración de compilación predeterminada va dirigida a navegadores que a
 
 ## Probar Vite online
 
-Puedes probar Vite online en [StackBlitz](https://vite.new/). Éste ejecuta la configuración de compilación basada en Vite directamente en el navegador, por lo que es casi idéntica a la configuración local pero con la diferencia que no requiere que instales nada en tu máquina. Puedes navegar a `vite.new/{template}` para seleccionar qué marco de trabajo utilizar.
+Puedes probar Vite online en [StackBlitz](https://vite.new/). Este ejecuta la configuración de compilación basada en Vite directamente en el navegador, por lo que es casi idéntica a la configuración local pero con la diferencia que no requiere que instales nada en tu máquina. Puedes navegar a `vite.new/{template}` para seleccionar qué marco de trabajo utilizar.
 
 Los ajustes preestablecidos de plantilla admitidos son:
 


### PR DESCRIPTION
Según la Real Academia Española (RAE), el uso de la palabra "éste" con tilde es incorrecto desde el año 2010. La RAE establece que los pronombres demostrativos (este, ese, aquel y sus variantes) no deben llevar tilde, salvo en casos de posible ambigüedad. La tilde diacrítica solo se usa para diferenciar el pronombre del adjetivo cuando ambos coinciden en género y número. Por ejemplo: "Este libro es mejor que ese" (sin tilde, pronombres) y "Éste es el libro que te dije" (con tilde, pronombre que se opone al adjetivo ese).

According to the Royal Spanish Academy (RAE), the use of the word "éste" with an accent mark is incorrect since 2010. The RAE states that demonstrative pronouns (este, ese, aquel and their variants) should not have an accent mark, except in cases of possible ambiguity. The diacritical accent is only used to differentiate the pronoun from the adjective when they both agree in gender and number. For example: "Este libro es mejor que ese" (without accent mark, pronouns) and "Éste es el libro que te dije" (with accent mark, pronoun that opposes the adjective ese).

https://www.rae.es/sites/default/files/Principales_novedades_de_la_Ortografia_de_la_lengua_espanola.pdf