### PR TITLE
update algolia to use spanish and not english

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -141,14 +141,14 @@ export default defineConfig({
             selectText: 'Seleccionar',
             navigateText: 'Cambiar',
             closeText: 'Cerrar',
-            searchByText: 'Buscar proveedor',
+            searchByText: 'Buscado por',
           },
           noResultsScreen: {
             noResultsText: 'No se encontraron resultados relacionados',
             suggestedQueryText: 'Puedes intentar buscar',
             reportMissingResultsText:
               '¿Crees que esta búsqueda debería tener resultados?',
-            reportMissingResultsLinkText: 'Informa un problema',
+            reportMissingResultsLinkText: 'Informar de un problema',
           },
         },
       },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -110,7 +110,47 @@ export default defineConfig({
       apiKey: 'deaab78bcdfe96b599497d25acc6460e',
       indexName: 'vitejs',
       searchParameters: {
-        facetFilters: ['tags:en'],
+        facetFilters: ['tags:es'],
+      },
+      placeholder: 'Buscar',
+      translations: {
+        button: {
+          buttonText: 'Buscar',
+        },
+
+        modal: {
+          searchBox: {
+            resetButtonTitle: 'Limpiar criterios de búsqueda',
+            resetButtonAriaLabel: 'Limpiar criterios de búsqueda',
+            cancelButtonText: 'Cancelar',
+            cancelButtonAriaLabel: 'Cancelar',
+          },
+          startScreen: {
+            recentSearchesTitle: 'Búsquedas recientes',
+            noRecentSearchesText: 'No hay búsquedas recientes',
+            saveRecentSearchButtonTitle: 'Guardar en búsquedas recientes',
+            removeRecentSearchButtonTitle: 'Eliminar de búsquedas recientes',
+            favoriteSearchesTitle: 'Favoritos',
+            removeFavoriteSearchButtonTitle: 'Eliminar de favoritos',
+          },
+          errorScreen: {
+            titleText: 'No se pueden obtener resultados',
+            helpText: 'Es posible que debas revisar tu conexión de red',
+          },
+          footer: {
+            selectText: 'Seleccionar',
+            navigateText: 'Cambiar',
+            closeText: 'Cerrar',
+            searchByText: 'Buscar proveedor',
+          },
+          noResultsScreen: {
+            noResultsText: 'No se encontraron resultados relacionados',
+            suggestedQueryText: 'Puedes intentar buscar',
+            reportMissingResultsText:
+              '¿Crees que esta búsqueda debería tener resultados?',
+            reportMissingResultsLinkText: 'Informa un problema',
+          },
+        },
       },
     },
 


### PR DESCRIPTION
Hello Vite team. 🙂
I see in the Spanish documentation that the search button is in English, so I create this pull request to update the algolia button to Spanish.

I see that in Chinese documentation  is translated, so I copied the configuration from the Chinese repo and updated with the Spanish translation.

Link from the Chinese documentation: https://github.com/vitejs/docs-cn/blob/main/.vitepress/config.ts#LL71C9-L71C22

Hope this can help.