### PR TITLE
ci(ryu-cho): cap default `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ryu-cho.yml
+++ b/.github/workflows/ryu-cho.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "*/5 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   ryu-cho:
     name: Ryu Cho


### PR DESCRIPTION
Ryu-Cho uses a separate PAT via `secrets.ACCESS_TOKEN` for its issue and PR writes, so the default `GITHUB_TOKEN` itself is not exercised on the write paths. Workflow-level `contents: read` is the appropriate ceiling here.

Post-CVE-2025-30066 (`tj-actions/changed-files` compromise) least-privilege hardening. YAML validated locally.