### PR TITLE
docs: sincronizar cambios desde upstream (junio 3)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -255,6 +255,10 @@ const config = defineConfig({
             link: '/acknowledgements',
           },
           {
+            text: 'Código de Conducta',
+            link: 'https://github.com/vitejs/.github/blob/main/CODE_OF_CONDUCT.md',
+          },
+          {
             text: 'Escenario en Vivo',
             link: '/live',
           },

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -52,7 +52,7 @@ Configurar `server.allowedHosts` en `true` permite que cualquier sitio web enví
 :::
 
 ::: details Configurar mediante variable de entorno
-Puedes configurar la variable de entorno `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` para agregar un host adicional permitido.
+Puedes configurar la variable de entorno `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` para añadir hosts permitidos adicionales. Usa comas para separar varios hosts (por ejemplo, `host1.example.com,host2.example.com`).
 :::
 
 ## server.port
@@ -180,17 +180,45 @@ Configurar `server.cors` en `true` permite que cualquier sitio web envíe solici
 
 ## server.hmr
 
-- **Tipo:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server }`
+- **Tipo:** `boolean | { overlay?: boolean }`
 
-Deshabilita o configura la conexión HMR (en los casos en que el websocket HMR deba usar una dirección diferente del servidor http).
+Desactiva o configura el comportamiento de HMR.
 
 Coloca `server.hmr.overlay` en `false` para deshabilitar la superposición de errores del servidor.
 
-`protocol` establece el protocolo WebSocket utilizado para la conexión HMR: `ws` (WebSocket) o `wss` (WebSocket Seguro).
+::: warning Opciones Obsoletas
 
-`clientPort` es una opción avanzada que sobreescribe el puerto solo en el lado del cliente, lo que le permite servir el websocket en un puerto diferente al que busca el código del cliente.
+Las opciones relacionadas a WebSocket (`protocol`, `host`, `port`, `path`, `clientPort`, `timeout`, `server`) están obsoletas. Usa [`server.ws`](#server-ws) en su lugar. Estas opciones se sincronizan automáticamente, por lo que las configuraciones existentes seguirán funcionando.
 
-Cuando se define `server.hmr.server`, Vite procesará las solicitudes de conexión HMR a través del servidor provisto. Si no está en modo middleware, Vite intentará procesar las solicitudes de conexión HMR a través del servidor existente. Esto puede ser útil cuando se usan certificados autofirmados o cuando desea exponer a Vite a través de una red en un solo puerto.
+:::
+
+## server.ws
+
+- **Tipo:** `false | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, clientPort?: number, server?: Server }`
+
+Configura las opciones de conexión WebSocket. Establécelo en `false` para desactivar la conexión WebSocket por completo.
+
+- `protocol` - Protocolo WebSocket (`ws` o `wss`)
+- `host` - Host del servidor WebSocket
+- `port` - Puerto del servidor WebSocket
+- `path` - Ruta WebSocket
+- `clientPort` - Sobrescribe el puerto en el lado del cliente, lo que te permite servir el websocket en un puerto diferente al que busca el código del cliente
+- `timeout` - Tiempo de espera de la conexión en milisegundos (predeterminado: 30000)
+- `server` - Usa un servidor HTTP personalizado para las conexiones WebSocket
+
+Cuando se define `server.ws.server`, Vite procesará las solicitudes de conexión WebSocket a través del servidor provisto. Si no está en modo middleware, Vite intentará procesar las solicitudes de conexión WebSocket a través del servidor existente. Esto puede ser útil cuando se usan certificados autofirmados o cuando deseas exponer a Vite a través de una red en un solo puerto.
+
+```js
+export default defineConfig({
+  server: {
+    ws: {
+      protocol: 'wss',
+      host: 'localhost',
+      port: 3001,
+    },
+  },
+})
+```
 
 Consulta [`vite-setup-catalogue`](https://github.com/sapphi-red/vite-setup-catalogue) para ver algunos ejemplos.
 
@@ -199,14 +227,14 @@ Consulta [`vite-setup-catalogue`](https://github.com/sapphi-red/vite-setup-catal
 Con la configuración predeterminada, se espera que los proxies inversos frente a Vite admitan WebSocket de proxy. Si el cliente de Vite HMR no logra conectar WebSocket, el cliente recurrirá a conectar WebSocket directamente al servidor de Vite HMR sin pasar por los proxies inversos:
 
 ```
-Direct websocket connection fallback. Check out https://vite.dev/config/server-options.html#server-hmr to remove the previous connection error.
+Direct websocket connection fallback. Check out https://vite.dev/config/server-options.html#server-ws to remove the previous connection error.
 ```
 
 Se puede ignorar el error que aparece en el navegador cuando ocurre el fallback. Para evitar el error al omitir directamente los proxies inversos, podrías:
 
 - configurar el proxy inverso para el proxy de WebSocket también
-- configurar [`server.strictPort = true`](#server-strictport) y configurar `server.hmr.clientPort` con el mismo valor que `server.port`
-- configurar `server.hmr.port` en un valor diferente de [`server.port`](#server-port)
+- configurar [`server.strictPort = true`](#server-strictport) y configurar `server.ws.clientPort` con el mismo valor que `server.port`
+- configurar `server.ws.port` en un valor diferente de [`server.port`](#server-port)
   :::
 
 ## server.forwardConsole

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -207,6 +207,48 @@ Habilita la función de resolución de rutas tsconfig. La opción `paths` en `ts
 
 Un placeholder de valor de nonce que se utilizará al generar etiquetas de script/style. Establecer este valor también generará una etiqueta meta con el valor de nonce.
 
+## html.additionalAssetSources
+
+- **Tipo:** `Record<string, HtmlAssetSource>`
+
+```ts
+interface HtmlAssetSource {
+  srcAttributes?: string[]
+  srcsetAttributes?: string[]
+  filter?: (data: {
+    key: string
+    value: string
+    attributes: Record<string, string>
+  }) => boolean
+}
+```
+
+Define elementos y atributos HTML adicionales que se tratarán como fuentes de recursos estáticos. Esto amplía la lista integrada que incluye elementos estándar como `<img src>`, `<video src>`, `<link href>`, etc.
+
+Esto es útil cuando se utilizan componentes web personalizados o atributos no estándar (como `data-*`) que hacen referencia a recursos estáticos.
+
+**Ejemplo:**
+
+```js
+export default defineConfig({
+  html: {
+    additionalAssetSources: {
+      // Componente web personalizado
+      'html-import': { srcAttributes: ['src'] },
+      // Agrega atributos data-* al elemento existente
+      img: { srcAttributes: ['data-src-dark', 'data-src-light'] },
+      // Con formato srcset
+      'my-picture': { srcsetAttributes: ['data-srcset'] },
+      // Con función de filtro
+      'my-component': {
+        srcAttributes: ['asset'],
+        filter: ({ attributes }) => attributes.type === 'image',
+      },
+    },
+  },
+})
+```
+
 ## css.modules
 
 - **Tipo:**

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -373,7 +373,7 @@ function loadEnv(
 
 **Relacionado:** [Archivos `.env`](./env-and-mode.md#archivos-env)
 
-Carga archivos `.env` dentro de `envDir`. De forma predeterminada, solo se cargan las variables env con el prefijo `VITE_`, a menos que se cambie `prefixes`.
+Carga los archivos `.env` que están dentro de `envDir` y los fusiona con las correspondientes variables que ya se encuentran presentes en `process.env`. Por defecto, solo se cargan las variables de entorno con el prefijo `VITE_`, a menos que se cambie `prefixes`.
 
 ## `normalizePath`
 

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -180,7 +180,7 @@ Si necesitas una integración personalizada, puedes seguir los pasos de esta gu�
    ```
 
    Cada entrada en el manifiesto representa uno de los siguientes:
-   - **Fragmentos de entrada**: Generados a partir de archivos especificados en [`build.rolldownOptions.input`](https://rollupjs.org/configuration-options/#input). Estos fragmentos tienen `isEntry: true` y su clave es la ruta src relativa desde la raíz del proyecto.
+   - **Fragmentos de entrada**: Generados a partir de archivos especificados en [`build.rolldownOptions.input`](https://rolldown.rs/reference/InputOptions.input#input). Estos fragmentos tienen `isEntry: true` y su clave es la ruta src relativa desde la raíz del proyecto.
    - **Fragmentos de entrada dinámica**: Generados a partir de importaciones dinámicas. Estos fragmentos tienen `isDynamicEntry: true` y su clave es la ruta src relativa desde la raíz del proyecto.
    - **Fragmentos no de entrada**: Su clave es el nombre base del archivo generado con `_` como prefijo.
    - **Fragmentos de activos**: Generados a partir de activos importados como imágenes, fuentes. Su clave es la ruta src relativa desde la raíz del proyecto.

--- a/docs/guide/static-deploy-github-pages.yaml
+++ b/docs/guide/static-deploy-github-pages.yaml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Configurar Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: lts/*
           cache: 'npm'
@@ -44,13 +44,13 @@ jobs:
       - name: Construir
         run: npm run build
       - name: Configurar Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Subir artefacto
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           # Subir la carpeta dist
           path: './dist'
       - name: Desplegar a GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 #endregion contenido


### PR DESCRIPTION
## Resumen

Sincroniza la documentación en español con los cambios recientes del repositorio principal de Vite.

## Issues resueltos

- #1974: Clarificar que `loadEnv` fusiona variables con `process.env`
- #1970: Actualizar enlace de `rolldownOptions` a `rolldown.rs`
- #1969: Agregar nueva opción `html.additionalAssetSources`
- #1968: Soporte de múltiples hosts en `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS`
- #1967: Renombrar opciones `server.hmr` a `server.ws`
- #1962: Agregar Código de Conducta a la navegación de recursos
- #1961: Fijar (pin) dependencias de GitHub Actions por SHA

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `docs/guide/api-javascript.md` | Aclaración sobre `loadEnv` y `process.env` |
| `docs/guide/backend-integration.md` | Enlace actualizado a `rolldown.rs` |
| `docs/config/shared-options.md` | Nueva sección `html.additionalAssetSources` |
| `docs/config/server-options.md` | Múltiples hosts + renombrado `server.hmr` → `server.ws` |
| `docs/.vitepress/config.ts` | Enlace al Código de Conducta en nav |
| `docs/guide/static-deploy-github-pages.yaml` | GitHub Actions pinned por SHA |

## Verificación

- ✅ `pnpm build` exitoso (84.48s)